### PR TITLE
use accuracy provided by Yandex locator

### DIFF
--- a/plugin/yandexonlinelocator.cpp
+++ b/plugin/yandexonlinelocator.cpp
@@ -340,9 +340,7 @@ bool YandexOnlineLocator::readServerResponseData(const QByteArray &data, QString
 
     bool accuracyOk = false;
 
-    // Yandex locator dont have accuracy
-    double accuracy = 0.0;
-    //double accuracy = obj.value("accuracy").toVariant().toDouble(&accuracyOk);
+    double accuracy = location["precision"].toDouble(&accuracyOk);
     if (!accuracyOk) {
         accuracy = -1;
     }


### PR DESCRIPTION
Yandex locator provides an accuracy value, in their response it is called precision: https://yandex.ru/dev/locator/doc/dg/api/json-reply.html

That seems very much in line what Mozilla provides: https://ichnaea.readthedocs.io/en/latest/api/geolocate.html#response

